### PR TITLE
- conditionally branched builds for iOS with LibTorch-Lite cocoapod

### DIFF
--- a/SMPL++/include/smpl/BlendShape.h
+++ b/SMPL++/include/smpl/BlendShape.h
@@ -32,7 +32,11 @@
 //===== INCLUDES ==============================================================
 
 //----------
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 //----------
 #include "toolbox/Exception.h"
 //----------

--- a/SMPL++/include/smpl/JointRegression.h
+++ b/SMPL++/include/smpl/JointRegression.h
@@ -31,7 +31,11 @@
 
 //===== INCLUDES ==============================================================
 
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 
 //===== EXTERNAL FORWARD DECLARATIONS =========================================
 

--- a/SMPL++/include/smpl/LinearBlendSkinning.h
+++ b/SMPL++/include/smpl/LinearBlendSkinning.h
@@ -31,7 +31,11 @@
 
 //===== INCLUDES ==============================================================
 
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 
 //===== EXTERNAL FORWARD DECLARATIONS =========================================
 

--- a/SMPL++/include/smpl/SMPL.h
+++ b/SMPL++/include/smpl/SMPL.h
@@ -35,7 +35,11 @@
 #include <string>
 //----------
 #include <nlohmann/json.hpp>
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 //----------
 #include "smpl/BlendShape.h"
 #include "smpl/JointRegression.h"

--- a/SMPL++/include/smpl/WorldTransformation.h
+++ b/SMPL++/include/smpl/WorldTransformation.h
@@ -31,7 +31,11 @@
 
 //===== INCLUDES ==============================================================
 
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 
 //===== EXTERNAL FORWARD DECLARATIONS =========================================
 

--- a/SMPL++/include/toolbox/Tester.h
+++ b/SMPL++/include/toolbox/Tester.h
@@ -31,7 +31,11 @@
 
 //===== INCLUDES ==============================================================
 
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif // TARGET_IOS
 
 //===== EXTERNAL FORWARD DECLARATIONS =========================================
 

--- a/SMPL++/include/toolbox/TorchEx.hpp
+++ b/SMPL++/include/toolbox/TorchEx.hpp
@@ -33,7 +33,11 @@
 
 //----------
 //----------
+#ifdef TARGET_IOS
+#include <LibTorch-Lite.h>
+#else
 #include <torch/torch.h>
+#endif
 //----------
 #include "toolbox/Exception.h"
 //----------


### PR DESCRIPTION
This PR fixes LibTorch-Lite build for iOS with Xcode.
Just add TARGET_IOS preprocessor directive to your target.